### PR TITLE
Include "logs": true in plugin.json

### DIFF
--- a/src/plugin.json
+++ b/src/plugin.json
@@ -4,6 +4,7 @@
   "name": "AstraDB",
   "id": "grafana-astradb-datasource",
   "metrics": true,
+  "logs": true,
   "backend": true,
   "annotations": true,
   "executable": "gpx_astradb",


### PR DESCRIPTION
I am working on the list of data sources that produce logs results and I've noticed that this data source doesn't have `"logs": true` in `plugin.json`, but it produces logs result.

<!-- To surface this PR in the changelog add the label: changelog -->
<!-- If this PR is going in the changelog please make sure the title of the PR explains the feature in a user-centric way: -->
<!-- Bad: fix state bug in hooks -->
<!-- Good: Fix crash when switching from Query Builder -->
