### PR TITLE
GHA: Harden workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,13 +85,9 @@ jobs:
 
       - name: Archive Build
         uses: actions/upload-artifact@v4
-        env:
-          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
-          PLUGIN_VERSION: ${{ steps.metadata.outputs.plugin-version }}
-          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         with:
-          name: ${PLUGIN_ID}-${PLUGIN_VERSION}
-          path: ${PLUGIN_ARCHIVE}
+          name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
+          path: ${{ steps.metadata.outputs.archive }}
           retention-days: 5
 
   resolve-versions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
@@ -21,6 +20,8 @@ jobs:
       archive: ${{ steps.metadata.outputs.archive }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -49,13 +50,13 @@ jobs:
           go-version-file: go.mod
 
       - name: Test backend
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: coverage
 
       - name: Build backend
-        uses: magefile/mage-action@v3
+        uses: magefile/mage-action@6f50bbb8ea47d56e62dee92392788acbc8192d0b
         with:
           version: latest
           args: buildAll
@@ -75,15 +76,22 @@ jobs:
 
       - name: Package plugin
         id: package-plugin
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         run: |
-          mv dist ${{ steps.metadata.outputs.plugin-id }}
-          zip ${{ steps.metadata.outputs.archive }} ${{ steps.metadata.outputs.plugin-id }} -r
+          mv dist ${PLUGIN_ID}
+          zip ${PLUGIN_ARCHIVE} ${PLUGIN_ID} -r
 
       - name: Archive Build
         uses: actions/upload-artifact@v4
+        env:
+          PLUGIN_ID: ${{ steps.metadata.outputs.plugin-id }}
+          PLUGIN_VERSION: ${{ steps.metadata.outputs.plugin-version }}
+          PLUGIN_ARCHIVE: ${{ steps.metadata.outputs.archive }}
         with:
-          name: ${{ steps.metadata.outputs.plugin-id }}-${{ steps.metadata.outputs.plugin-version }}
-          path: ${{ steps.metadata.outputs.archive }}
+          name: ${PLUGIN_ID}-${PLUGIN_VERSION}
+          path: ${PLUGIN_ARCHIVE}
           retention-days: 5
 
   resolve-versions:
@@ -111,6 +119,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -131,9 +141,12 @@ jobs:
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
       - name: Unpack build
+        env:
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ needs.build.outputs.archive }}
         run: |
-          unzip ${{ needs.build.outputs.archive }}
-          mv ${{ needs.build.outputs.plugin-id }} dist
+          unzip ${PLUGIN_ARCHIVE}
+          mv ${PLUGIN_ID} dist
 
       - name: Start Grafana
         shell: bash
@@ -160,6 +173,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -180,9 +195,12 @@ jobs:
           name: ${{ needs.build.outputs.plugin-id }}-${{ needs.build.outputs.plugin-version }}
 
       - name: Unpack build
+        env:
+          PLUGIN_ID: ${{ needs.build.outputs.plugin-id }}
+          PLUGIN_ARCHIVE: ${{ needs.build.outputs.archive }}
         run: |
-          unzip ${{ needs.build.outputs.archive }}
-          mv ${{ needs.build.outputs.plugin-id }} dist
+          unzip ${PLUGIN_ARCHIVE}
+          mv ${PLUGIN_ID} dist
 
       - name: Start Grafana
         shell: bash

--- a/.github/workflows/detect-breaking-changes.yml
+++ b/.github/workflows/detect-breaking-changes.yml
@@ -6,6 +6,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'

--- a/.github/workflows/issue_commands.yml
+++ b/.github/workflows/issue_commands.yml
@@ -9,9 +9,10 @@ jobs:
       - name: Checkout Actions
         uses: actions/checkout@v4
         with:
-          repository: "grafana/grafana-github-actions"
+          repository: 'grafana/grafana-github-actions'
           path: ./actions
           ref: main
+          persist-credentials: false
       - name: Install Actions
         run: npm install --production --prefix ./actions
       - name: Run Commands

--- a/.github/workflows/pull-request-image.yml
+++ b/.github/workflows/pull-request-image.yml
@@ -63,7 +63,7 @@ jobs:
         shell: bash
         env:
           GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
-          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          SHA: ${{ github.event.pull_request.head.sha }}
           PR_NUMBER: ${{ github.event.number }}
         run: |
           echo "FROM grafana/grafana-oss:latest
@@ -78,7 +78,7 @@ jobs:
           ENV GF_DEFAULT_APP_MODE "development"
 
           # TODO: Cleanup script should remove images from closed PRs using these labels
-          LABEL gh-sha="${GITHUB_SHA}"
+          LABEL gh-sha="${SHA}"
           LABEL gh-repo="${GITHUB_REPOSITORY_NAME}"
           LABEL gh-pr-number="${PR_NUMBER}"
 

--- a/.github/workflows/pull-request-image.yml
+++ b/.github/workflows/pull-request-image.yml
@@ -6,10 +6,6 @@ on:
     branches:
       - main
 
-permissions:
-  pull-requests: write
-  issues: write
-
 jobs:
   build:
     name: Build and archive plugin build artifacts
@@ -18,6 +14,8 @@ jobs:
       fail-fast: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -63,6 +61,10 @@ jobs:
 
       - name: Generate Dockerfile
         shell: bash
+        env:
+          GITHUB_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           echo "FROM grafana/grafana-oss:latest
 
@@ -76,21 +78,21 @@ jobs:
           ENV GF_DEFAULT_APP_MODE "development"
 
           # TODO: Cleanup script should remove images from closed PRs using these labels
-          LABEL gh-sha="${{ github.event.pull_request.head.sha }}"
-          LABEL gh-repo="${{ github.event.repository.name }}"
-          LABEL gh-pr-number="${{ github.event.number }}"
+          LABEL gh-sha="${GITHUB_SHA}"
+          LABEL gh-repo="${GITHUB_REPOSITORY_NAME}"
+          LABEL gh-pr-number="${PR_NUMBER}"
 
           # Copy plugin build artifacts into the image
-          COPY . /var/lib/grafana/plugins/${{ github.event.repository.name }}/" > Dockerfile
+          COPY . /var/lib/grafana/plugins/${GITHUB_REPOSITORY_NAME}/" > Dockerfile
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@14487ce63c7a62a4a324b0bfb37086795e31c6c1
         with:
           context: .
           file: ./Dockerfile
@@ -98,18 +100,21 @@ jobs:
           tags: grafana/plugin-builds:${{ github.event.pull_request.head.sha }}pre
   add_pr_comment:
     name: Add PR comment
+    permissions:
+      pull-requests: write
+      issues: write
     runs-on: ubuntu-latest
     needs: push_to_registry
     steps:
       - name: Find previous comment (if any)
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@3eae4d37986fb5a8592848f6a574fdf654e61f9e
         id: fc
         with:
           issue-number: ${{ github.event.number }}
           body-includes: Use the following command to run this PR with Docker
       - name: Update comment on PR
         if: steps.fc.outputs.comment-id != ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           edit-mode: replace
@@ -122,7 +127,7 @@ jobs:
               ```
       - name: Add comment to PR
         if: steps.fc.outputs.comment-id == ''
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043
         with:
           issue-number: ${{ github.event.number }}
           body: |


### PR DESCRIPTION
Fixing a bunch of issues reported by `zizmor`.

- Fix template injection issues.
- Pin third-party GitHub actions to specific SHAs. Excluding GitHub owned actions.
- Appropriately set permissions in workflows.
- Improve safety of checkout action.