### PR TITLE
Release 1.0.5

### DIFF
--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -29,3 +29,5 @@ services:
       GF_LOG_LEVEL: debug
       GF_DATAPROXY_LOGGING: 1
       GF_PLUGINS_ALLOW_LOADING_UNSIGNED_PLUGINS: grafana-astradb-datasource
+      GF_FEATURE_TOGGLES_splashScreen: false
+      GF_FEATURE_TOGGLES_dashboardNewLayouts: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.5
+
+- **Chore** - Dependency updates
+- **Chore** - React v19 readiness, bump Node and use npm (#681)
+
 ## 1.0.4
 
 - **Chore** - Dependency updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astradb-datasource",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Grafana Data Source Backend Plugin for Astra DB",
   "private": true,
   "scripts": {


### PR DESCRIPTION
## 1.0.5

- **Chore** - Dependency updates
- **Chore** - React v19 readiness, bump Node and use npm (#681)
