### PR TITLE
chore: Disable install scripts in package manager configs

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+
+ignore-scripts=true


### PR DESCRIPTION
This change disables lifecycle scripts where package manager config files are present.

- Yarn 2+: `enableScripts: false` in `.yarnrc.yml`
- Yarn classic: `enableScripts false` in `.yarnrc`
- npm: `ignore-scripts=true` in `.npmrc`

See:
- https://yarnpkg.com/configuration/yarnrc#enableScripts
- https://docs.npmjs.com/cli/v10/using-npm/config#ignore-scripts

[_Created by Sourcegraph batch change `Kristian.Bremberg/disable-lifecycle-scripts-auto`._](https://grafana.sourcegraph.com/users/Kristian.Bremberg/batch-changes/disable-lifecycle-scripts-auto)